### PR TITLE
Switch to Terrapin gem

### DIFF
--- a/1.0_RELEASE_GOALS.md
+++ b/1.0_RELEASE_GOALS.md
@@ -4,4 +4,4 @@ youtube-dl.rb hits 1.0 when:
 * [x] It works on Windows
 * [ ] It fully supports all features of youtube-dl in a Ruby-friendly way
 * [ ] It supports logging
-* [ ] [It uses v1.0 Cocaine](https://github.com/thoughtbot/cocaine/blob/master/GOALS)
+* [ ] [It uses v1.0 Terrapin](https://github.com/thoughtbot/terrapin/blob/master/GOALS)

--- a/lib/youtube-dl.rb
+++ b/lib/youtube-dl.rb
@@ -1,4 +1,4 @@
-require 'cocaine'
+require 'terrapin'
 require 'json'
 require 'ostruct'
 
@@ -32,20 +32,20 @@ module YoutubeDL
   #
   # @return [Array] list of extractors
   def extractors
-    @extractors ||= cocaine_line('--list-extractors').run.split("\n")
+    @extractors ||= terrapin_line('--list-extractors').run.split("\n")
   end
 
   # Returns youtube-dl's version
   #
   # @return [String] youtube-dl version
   def binary_version
-    @binary_version ||= cocaine_line('--version').run.strip
+    @binary_version ||= terrapin_line('--version').run.strip
   end
 
   # Returns user agent
   #
   # @return [String] user agent
   def user_agent
-    @user_agent ||= cocaine_line('--dump-user-agent').run.strip
+    @user_agent ||= terrapin_line('--dump-user-agent').run.strip
   end
 end

--- a/lib/youtube-dl/options.rb
+++ b/lib/youtube-dl/options.rb
@@ -134,7 +134,7 @@ module YoutubeDL
       # Symbolize
       manipulate_keys! { |key_name| key_name.is_a?(Symbol) ? key_name : key_name.to_sym }
 
-      # Underscoreize (because Cocaine doesn't like hyphens)
+      # Underscoreize (because Terrapin doesn't like hyphens)
       manipulate_keys! { |key_name| key_name.to_s.tr('-', '_').to_sym }
     end
 

--- a/lib/youtube-dl/runner.rb
+++ b/lib/youtube-dl/runner.rb
@@ -32,26 +32,26 @@ module YoutubeDL
       @executable_path ||= usable_executable_path_for(@executable)
     end
 
-    # Returns Cocaine's runner engine
+    # Returns Terrapin's runner engine
     #
     # @return [CommandLineRunner] backend runner class
     def backend_runner
-      Cocaine::CommandLine.runner
+      Terrapin::CommandLine.runner
     end
 
-    # Sets Cocaine's runner engine
+    # Sets Terrapin's runner engine
     #
-    # @param cocaine_runner [CommandLineRunner] backend runner class
-    # @return [Object] whatever Cocaine::CommandLine.runner= returns.
-    def backend_runner=(cocaine_runner)
-      Cocaine::CommandLine.runner = cocaine_runner
+    # @param terrapin_runner [CommandLineRunner] backend runner class
+    # @return [Object] whatever Terrapin::CommandLine.runner= returns.
+    def backend_runner=(terrapin_runner)
+      Terrapin::CommandLine.runner = terrapin_runner
     end
 
     # Returns the command string without running anything
     #
     # @return [String] command line string
     def to_command
-      cocaine_line(options_to_commands).command(@options.store)
+      terrapin_line(options_to_commands).command(@options.store)
     end
     alias_method :command, :to_command
 
@@ -59,7 +59,7 @@ module YoutubeDL
     #
     # @return [String] the output of youtube-dl
     def run
-      cocaine_line(options_to_commands).run(@options.store)
+      terrapin_line(options_to_commands).run(@options.store)
     end
     alias_method :download, :run
 
@@ -75,9 +75,9 @@ module YoutubeDL
 
     private
 
-    # Parses options and converts them to Cocaine's syntax
+    # Parses options and converts them to Terrapin's syntax
     #
-    # @return [String] commands ready to do cocaine
+    # @return [String] commands ready to do terrapin
     def options_to_commands
       commands = []
       @options.sanitize_keys.each_paramized_key do |key, paramized_key|

--- a/lib/youtube-dl/support.rb
+++ b/lib/youtube-dl/support.rb
@@ -19,14 +19,14 @@ module YoutubeDL
 
     alias_method :executable_path_for, :usable_executable_path_for
 
-    # Helper for doing lines of cocaine (initializing, auto executable stuff, etc)
+    # Helper for doing lines of terrapin (initializing, auto executable stuff, etc)
     #
     # @param command [String] command switches to run
     # @param executable_path [String] executable to run. Defaults to usable youtube-dl.
-    # @return [Cocaine::CommandLine] initialized Cocaine instance
-    def cocaine_line(command, executable_path = nil)
+    # @return [Terrapin::CommandLine] initialized Terrapin instance
+    def terrapin_line(command, executable_path = nil)
       executable_path = executable_path_for('youtube-dl') if executable_path.nil?
-      Cocaine::CommandLine.new(executable_path, command)
+      Terrapin::CommandLine.new(executable_path, command)
     end
 
     # Helper to add quotes to beginning and end of a URL or whatever you want....

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,8 @@ if RUBY_PLATFORM == "java"
   require 'simplecov'
   SimpleCov.start
 else
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
+  # require "codeclimate-test-reporter"
+  # CodeClimate::TestReporter.start
 end
 
 $:.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))

--- a/test/youtube-dl/runner_test.rb
+++ b/test/youtube-dl/runner_test.rb
@@ -32,12 +32,12 @@ describe YoutubeDL::Runner do
   end
 
   describe '#backend_runner=, #backend_runner' do
-    it 'should set cocaine runner' do
-      @runner.backend_runner = Cocaine::CommandLine::BackticksRunner.new
-      assert_instance_of Cocaine::CommandLine::BackticksRunner, @runner.backend_runner
+    it 'should set terrapin runner' do
+      @runner.backend_runner = Terrapin::CommandLine::BackticksRunner.new
+      assert_instance_of Terrapin::CommandLine::BackticksRunner, @runner.backend_runner
 
-      @runner.backend_runner = Cocaine::CommandLine::PopenRunner.new
-      assert_instance_of Cocaine::CommandLine::PopenRunner, @runner.backend_runner
+      @runner.backend_runner = Terrapin::CommandLine::PopenRunner.new
+      assert_instance_of Terrapin::CommandLine::PopenRunner, @runner.backend_runner
     end
   end
 

--- a/test/youtube-dl/support_test.rb
+++ b/test/youtube-dl/support_test.rb
@@ -34,18 +34,18 @@ describe YoutubeDL::Support do
     end
   end
 
-  describe '#cocaine_line' do
-    it 'should return a Cocaine::CommandLine instance' do
-      assert_instance_of Cocaine::CommandLine, @klass.cocaine_line('')
+  describe '#terrapin_line' do
+    it 'should return a Terrapin::CommandLine instance' do
+      assert_instance_of Terrapin::CommandLine, @klass.terrapin_line('')
     end
 
     it 'should be able to override the executable' do
-      line = @klass.cocaine_line('hello', 'echo')
+      line = @klass.terrapin_line('hello', 'echo')
       assert_equal "echo hello", line.command
     end
 
     it 'should default to youtube-dl' do
-      line = @klass.cocaine_line(@klass.quoted(TEST_URL))
+      line = @klass.terrapin_line(@klass.quoted(TEST_URL))
       assert_includes line.command, "youtube-dl \"#{TEST_URL}\""
     end
   end

--- a/youtube-dl.rb.gemspec
+++ b/youtube-dl.rb.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'cocaine', '>=0.5.4'
+  spec.add_dependency 'terrapin', '>=0.5.4'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
The cocaine gem was renamed by thoughtbot and gives a deprecation warning when it's included. 